### PR TITLE
Stop installing :development gem group when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.4.2
 WORKDIR /app
 ADD . /app
-RUN bundle install
+RUN bundle install --without development
 ENTRYPOINT ["/bin/bash", "/app/run-reports.sh"]


### PR DESCRIPTION
Allo Gubnah.

Super minor change to your excellent Dockerfile.
Gemfiles (like [ours](https://github.com/NYPL/search-analytics-report-creator/blob/master/Gemfile)) allow you to break up your gem dependencies into arbitrarily named namespaces.

I've put non-essential gems in a namespace called `:development`.
`bundle install` has a `--without` flag specifically to avoid installing things like test frameworks on prod environments.

This should make a small cut in our `docker build` time too!

