### PR TITLE
Add Basic Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,26 +35,38 @@ USAGE: ruby ./script/create_analytics_reports.rb [options]
     -h, --help                       Prints this help
 ```
 
-Examples: 
+Examples:
 
 `ruby script/create_analytics_report.rb --id ga:xxx --auth-file ./config/google_auth.json --start-date 2017-10-26 --end-date 2017-11-02 -o ~/Desktop/`
 
 `ruby script/create_analytics_report.rb --id ga:xxx --auth-file ./config/google_auth.json --start-date 2017-10-26 --end-date 2017-11-02 -o google-sheets --google-parent-id SomeGoogleParentFolderId`
 
+## Git & Release Workflow
+
+Pull requests should be made against master.
+When a new version is ready for deployment:
+
+
+1.  Create a new tag and push it to github:  
+`git tag -am "SEMVER" SEMVER && git push origin SEMVER`
+
+1.  Build a Docker image, from that checkout out tag, and push it to ECS.  
+See [Building & Pushing to AWS ECR](#building-and-pushing) for more info.
+
 ## Docker
 
-## Building & Pushing to AWS ECR
+## <a name="building-and-pushing"></a>Building & Pushing to AWS ECR
 
 We host our built images on [Amazon ECR](https://aws.amazon.com/ecr/).
 
-1. "log in" to ECR:  `aws ecr get-login --no-include-email --region us-east-1 --profile [ACCOUNT-NAME] | /bin/bash`
+1. "log in" to ECR:  `aws ecr get-login --no-include-email --region us-east-1 --profile [ACCOUNT-NAME] | /bin/bash`.   
 If you receive an "Unknown options: --no-include-email" error, install the latest version of the AWS CLI.
 
-1.  Build your image `docker build --no-cache -t nypl/search-analytics-report-creator:[TAGNAME] .`
+1.  Build your image `docker build --no-cache -t nypl/search-analytics-report-creator:[TAGNAME] .`  
 You **MUST NOT** use an existing tag name. You must increment its semver.
 You can skip this step if your image is already built.
 
-1.  Link your local tag to the remote one: `docker tag nypl/search-analytics-report-creator:[TAGNAME] [ACCOUNT-ID].dkr.ecr.us-east-1.amazonaws.com/nypl/search-analytics-report-creator:[TAGNAME]`
+1.  Link your local tag to the remote one: `docker tag nypl/search-analytics-report-creator:[TAGNAME]   [ACCOUNT-ID].dkr.ecr.us-east-1.amazonaws.com/nypl/search-analytics-report-creator:[TAGNAME]`
 
 1.  Actually push: `docker push nypl/search-analytics-report-creator:[TAGNAME]`
 
@@ -63,8 +75,3 @@ You can skip this step if your image is already built.
 And use `--env-file` flag to run Docker image with corresponding environment variable file.
 
 `docker run --env-file config/.env.sample [name-or-id-of-docker-image]`
-
-
-## Deploying
-
-Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/lib/google_api_client.rb
+++ b/lib/google_api_client.rb
@@ -4,14 +4,13 @@ require 'google/apis/analytics_v3'
 require 'google/apis/sheets_v4'
 
 class GoogleApiClient
+
+  DRIVE_FILE = Google::Apis::DriveV3::File
+
   def initialize(options = {auth_file: nil})
     @auth_file = options[:auth_file]
 
     raise "missing auth_file" if @auth_file.nil?
-  end
-
-  def drive_file
-    Google::Apis::DriveV3::File
   end
 
   def analytics_client

--- a/lib/google_api_client.rb
+++ b/lib/google_api_client.rb
@@ -1,0 +1,49 @@
+require 'google/apis/drive_v3'
+require 'googleauth'
+require 'google/apis/analytics_v3'
+require 'google/apis/sheets_v4'
+
+class GoogleApiClient
+  def initialize(options = {auth_file: nil})
+    @auth_file = options[:auth_file]
+
+    raise "missing auth_file" if @auth_file.nil?
+  end
+
+  def drive_file
+    Google::Apis::DriveV3::File
+  end
+
+  def analytics_client
+    client = Google::Apis::AnalyticsV3::AnalyticsService.new
+    client.authorization = auth_analytics
+    client
+  end
+
+  def drive_client
+    client = Google::Apis::DriveV3::DriveService.new
+    client.authorization = auth_drive
+    client
+  end
+
+  def sheets_client
+    client = Google::Apis::SheetsV4::SheetsService.new
+    client.authorization = auth_drive
+    client
+  end
+
+  def auth_analytics
+    auth(scopes: ['https://www.googleapis.com/auth/analytics.readonly'])
+  end
+
+  def auth_drive
+    auth(scopes: ['https://www.googleapis.com/auth/drive.file'])
+  end
+
+private
+
+  def auth(scopes: [])
+    Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: File.open(@auth_file, 'r'), scope: scopes)
+  end
+
+end

--- a/lib/json_logger.rb
+++ b/lib/json_logger.rb
@@ -8,7 +8,7 @@ class JsonLogger
     @logger = Logger.new(STDOUT) # or retrieve the default application logger
     @logger.level = Object.const_get "Logger::#{options[:log_level].to_s.upcase}"
     @logger.formatter = proc do |severity, datetime, progname, msg|
-      JSON.fast_generate({level: severity, timestamp: datetime, message: msg})
+      JSON.fast_generate({level: severity, timestamp: datetime, message: msg}) << "\n"
     end
   end
 end

--- a/lib/json_logger.rb
+++ b/lib/json_logger.rb
@@ -1,0 +1,14 @@
+require 'logger'
+require 'json'
+
+# Logs to stdout. All the time.
+class JsonLogger
+  attr_reader :logger
+  def initialize(options = {log_level: :info})
+    @logger = Logger.new(STDOUT) # or retrieve the default application logger
+    @logger.level = Object.const_get "Logger::#{options[:log_level].to_s.upcase}"
+    @logger.formatter = proc do |severity, datetime, progname, msg|
+      JSON.fast_generate({level: severity, timestamp: datetime, message: msg})
+    end
+  end
+end

--- a/lib/report_generators/search_term_by_repo_and_searched_from.rb
+++ b/lib/report_generators/search_term_by_repo_and_searched_from.rb
@@ -161,7 +161,7 @@ class SearchTermByRepoAndSearchedFrom
     drive_client = @google_api_client.drive_client
 
     # Upload a file
-    metadata = @google_api_client.drive_file.new(name: self.report_basename, mime_type: 'application/vnd.google-apps.spreadsheet')
+    metadata = GoogleApiClient::DRIVE_FILE.new(name: self.report_basename, mime_type: 'application/vnd.google-apps.spreadsheet')
     file = drive_client.create_file(metadata, upload_source: self.report_output_path, content_type: 'text/csv', supports_team_drives: true)
     drive_client.update_file(file.id, add_parents: @google_parent_id)
 

--- a/lib/report_generators/search_term_by_repo_and_searched_from.rb
+++ b/lib/report_generators/search_term_by_repo_and_searched_from.rb
@@ -1,13 +1,10 @@
-require 'google/apis/drive_v3'
-require 'googleauth'
-require 'google/apis/analytics_v3'
-require 'google/apis/sheets_v4'
 require 'date'
+require File.join(__dir__, '..', 'google_api_client')
 
 class SearchTermByRepoAndSearchedFrom
 
   def initialize(options = {})
-    @auth_file     = options[:auth_file]
+    @google_api_client  = GoogleApiClient.new(auth_file: options[:auth_file])
     @ga_profile_id = options[:ga_profile_id]
     @start_date    = options[:start_date]
     @end_date      = options[:end_date]
@@ -31,24 +28,11 @@ class SearchTermByRepoAndSearchedFrom
     (@output == "google-sheets") ? File.join(File.absolute_path('.'), self.report_basename) : File.join(File.absolute_path(@output), self.report_basename)
   end
 
-  def auth_analytics
-    auth(scopes: ['https://www.googleapis.com/auth/analytics.readonly'])
-  end
-
-  def auth_drive
-    auth(scopes: ['https://www.googleapis.com/auth/drive.file'])
-  end
-
-  def auth(scopes: [])
-    Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: File.open(@auth_file, 'r'), scope: scopes)
-  end
-
   def generate_report!
-    stats = Google::Apis::AnalyticsV3::AnalyticsService.new
-    stats.authorization = auth_analytics
+    analytics_client = @google_api_client.analytics_client
 
-    query_response = stats.get_ga_data(@ga_profile_id, @start_date, @end_date, 'ga:totalEvents,ga:uniqueEvents', dimensions: 'ga:eventLabel,ga:eventAction,ga:dimension1,ga:dimension2', max_results: 10000, filters: "ga:eventCategory==Search;ga:eventAction==QuerySent", sort: "-ga:totalEvents")
-    click_response = stats.get_ga_data(@ga_profile_id, @start_date, @end_date, 'ga:totalEvents,ga:uniqueEvents,ga:avgEventValue', dimensions: 'ga:eventLabel,ga:eventAction,ga:dimension1,ga:dimension2', max_results: 10000, filters: "ga:eventCategory==Search;ga:eventAction==Clickthrough", sort: "ga:eventLabel")
+    query_response = analytics_client.get_ga_data(@ga_profile_id, @start_date, @end_date, 'ga:totalEvents,ga:uniqueEvents', dimensions: 'ga:eventLabel,ga:eventAction,ga:dimension1,ga:dimension2', max_results: 10000, filters: "ga:eventCategory==Search;ga:eventAction==QuerySent", sort: "-ga:totalEvents")
+    click_response = analytics_client.get_ga_data(@ga_profile_id, @start_date, @end_date, 'ga:totalEvents,ga:uniqueEvents,ga:avgEventValue', dimensions: 'ga:eventLabel,ga:eventAction,ga:dimension1,ga:dimension2', max_results: 10000, filters: "ga:eventCategory==Search;ga:eventAction==Clickthrough", sort: "ga:eventLabel")
 
     queries = []
     clicks  = []
@@ -172,22 +156,19 @@ class SearchTermByRepoAndSearchedFrom
   end
 
   def upload_to_drive
-    drive = Google::Apis::DriveV3::DriveService.new
-    drive.authorization = auth_drive
+    drive_client = @google_api_client.drive_client
 
     # Upload a file
-    metadata = Google::Apis::DriveV3::File.new(name: self.report_basename, mime_type: 'application/vnd.google-apps.spreadsheet')
-    file = drive.create_file(metadata, upload_source: self.report_output_path, content_type: 'text/csv', supports_team_drives: true)
-    drive.update_file(file.id, add_parents: @google_parent_id)
+    metadata = @google_api_client.drive_file.new(name: self.report_basename, mime_type: 'application/vnd.google-apps.spreadsheet')
+    file = drive_client.create_file(metadata, upload_source: self.report_output_path, content_type: 'text/csv', supports_team_drives: true)
+    drive_client.update_file(file.id, add_parents: @google_parent_id)
 
     filter_spreadsheet(file)
   end
 
   def filter_spreadsheet(file)
-    sheets = Google::Apis::SheetsV4::SheetsService.new
-    sheets.authorization = auth_drive
-    
-    spreadsheet = sheets.get_spreadsheet(file.id)
+    sheets_client = @google_api_client.sheets_client
+    spreadsheet = sheets_client.get_spreadsheet(file.id)
 
     requests = {
       requests: [
@@ -251,8 +232,8 @@ class SearchTermByRepoAndSearchedFrom
         }}
       ]
     }
-    
-    sheets.batch_update_spreadsheet(file.id, requests, {})
+
+    sheets_client.batch_update_spreadsheet(file.id, requests, {})
   end
 
   def mean_ordinality_over_segments(clickthrough_segments)

--- a/script/create_analytics_report.rb
+++ b/script/create_analytics_report.rb
@@ -1,7 +1,12 @@
+lib_dir = File.join(File.absolute_path(__dir__), '..', 'lib')
 require 'optparse'
-require File.join(File.absolute_path(__dir__), '..', 'lib', 'report_runner')
+require File.join(lib_dir, 'report_runner')
+require File.join(lib_dir, 'json_logger')
+
+logger = JsonLogger.new.logger
 
 options = {}
+
 OptionParser.new do |parser|
   parser.banner = 'USAGE: ruby ./script/create_analytics_reports.rb [options]'
 
@@ -36,6 +41,7 @@ OptionParser.new do |parser|
 end.parse!
 
 report_runner = ReportRunner.new(options)
+logger.info("starting to run analytics report with options #{options}")
 
 if !report_runner.valid?
   puts "\nError running report, errors: #{report_runner.errors.join(', ')}\n\n"
@@ -43,3 +49,5 @@ if !report_runner.valid?
 else
   report_runner.generate_report
 end
+
+logger.info("finished running analytics report")

--- a/spec/google_api_client_spec.rb
+++ b/spec/google_api_client_spec.rb
@@ -8,8 +8,8 @@ describe GoogleApiClient do
     expect{GoogleApiClient.new()}.to raise_error("missing auth_file")
   end
 
-  it "drive_file return a Google::Apis::DriveV3::File" do
-    expect(@google_api_client.drive_file).to equal(Google::Apis::DriveV3::File)
+  it "DRIVE_FILE return a Google::Apis::DriveV3::File" do
+    expect(GoogleApiClient::DRIVE_FILE).to equal(Google::Apis::DriveV3::File)
   end
   
 end

--- a/spec/google_api_client_spec.rb
+++ b/spec/google_api_client_spec.rb
@@ -1,0 +1,15 @@
+describe GoogleApiClient do
+
+  before do
+    @google_api_client = GoogleApiClient.new(auth_file: File.join(__dir__, 'resources', 'google_auth.example.json'))
+  end
+
+  it "will raise an exception if not instantiated with a auth file" do
+    expect{GoogleApiClient.new()}.to raise_error("missing auth_file")
+  end
+
+  it "drive_file return a Google::Apis::DriveV3::File" do
+    expect(@google_api_client.drive_file).to equal(Google::Apis::DriveV3::File)
+  end
+  
+end

--- a/spec/resources/google_auth.example.json
+++ b/spec/resources/google_auth.example.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "ga-api-spike",
+  "private_key_id": "a-long-number",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nTHE CONTENTS OF A PROVATE KEY\n-----END PRIVATE KEY-----\n",
+  "client_email": "username@ga-api-spike.iam.gserviceaccount.com",
+  "client_id": "a-long-number",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/my-spike-credentials%40ga-api-spike.iam.gserviceaccount.com"
+}

--- a/spec/search_term_by_repo_and_searched_from_spec.rb
+++ b/spec/search_term_by_repo_and_searched_from_spec.rb
@@ -2,7 +2,7 @@ describe SearchTermByRepoAndSearchedFrom do
   describe "ordinality" do
 
     it "will calculate mean ordinality across multiple clicks segmented by repo" do
-      report = SearchTermByRepoAndSearchedFrom.new
+      report = SearchTermByRepoAndSearchedFrom.new(auth_file: path_to_auth)
       clickthrough_segments = [
         instance_double("ClickResponse", :searched_repo => 'repo1', :total_events => 1, :mean_ordinality => 10.0),
         instance_double("ClickResponse", :searched_repo => 'repo2', :total_events => 10, :mean_ordinality => 3.0),
@@ -17,21 +17,25 @@ describe SearchTermByRepoAndSearchedFrom do
   describe "report_basename" do
 
     it "'yesterday' as a start_date or end_date will turn into the appropriate YYYY-MM-DD" do
-      report = SearchTermByRepoAndSearchedFrom.new(start_date: 'yesterday', end_date: 'yesterday')
+      report = SearchTermByRepoAndSearchedFrom.new(start_date: 'yesterday', end_date: 'yesterday', auth_file: path_to_auth)
       yesterday_as_string  = (Date.today - 1).strftime
       expect(report.report_basename).to eq("output_#{yesterday_as_string}_#{yesterday_as_string}.csv")
     end
 
     it "'today' as a start_date or end_date will turn into the appropriate YYYY-MM-DD" do
-      report = SearchTermByRepoAndSearchedFrom.new(start_date: 'today', end_date: 'today')
+      report = SearchTermByRepoAndSearchedFrom.new(start_date: 'today', end_date: 'today', auth_file: path_to_auth)
       today_as_string  = (Date.today).strftime
       expect(report.report_basename).to eq("output_#{today_as_string}_#{today_as_string}.csv")
     end
 
     it "accepts YYYY-MM-DD as start_date and end_date" do
-      report = SearchTermByRepoAndSearchedFrom.new(start_date: '1980-09-16', end_date: 'today')
+      report = SearchTermByRepoAndSearchedFrom.new(start_date: '1980-09-16', end_date: 'today', auth_file: path_to_auth)
       today_as_string  = (Date.today).strftime
       expect(report.report_basename).to eq("output_1980-09-16_#{today_as_string}.csv")
     end
   end
+end
+
+def path_to_auth
+  File.open(File.join(__dir__, 'resources', 'google_auth.example.json'))
 end


### PR DESCRIPTION
Hey @thisisstephenbetts.

This branch got a _litttlleeeee out of scope_.

## Logging

There's very little work for the logging here.

There's a new class, [JsonLogger](https://github.com/NYPL/search-analytics-report-creator/compare/ss/add-logging?expand=1#diff-3847d8ae0d4fd7d96bfa543ef69a8995).

Developers can make a call like: `my_logger = JsonLogger.new(log_level: 'debug').logger`  
From that point they can call `my_logger.info('message')`  and it will log messages that comply with [our logging standard](https://github.com/NYPL/engineering-general/blob/master/standards/logging.md).

Because ECS will log anything sent to stdout...this logger only sends messages to stdout.

### Using The New Logger

I only use it in the main CLI script, [create_analytics_report.rb](https://github.com/NYPL/search-analytics-report-creator/compare/ss/add-logging?expand=1#diff-7782733b7528893c7a23ae1cb2043520), for now. It will just log when the script starts, and when it ends.

## My Other Work

`[search_term_by_repo_and_searched_from.rb](https://github.com/NYPL/search-analytics-report-creator/compare/ss/add-logging?expand=1#diff-6869e12baf3a292372f029194ea0efe9)` has too many responsibilities.

I factored out all google-api related work to a [GoogleApiCient](https://github.com/NYPL/search-analytics-report-creator/compare/ss/add-logging?expand=1#diff-ecd99fa3c7b809c45b13bec10a5b2c85) class. and now the SearchTermByRepoAndSearchedFrom
is _composed of_ a GoogleApiCient rather than implementing those features directly.
