### PR TITLE
Paginate calls to GA

### DIFF
--- a/lib/report_generators/search_term_by_repo_and_searched_from.rb
+++ b/lib/report_generators/search_term_by_repo_and_searched_from.rb
@@ -266,7 +266,6 @@ private
   def get_query_rows(analytics_client, start_index = 1, response_rows = [])
     response = analytics_client.get_ga_data(@ga_profile_id, @start_date, @end_date, 'ga:totalEvents,ga:uniqueEvents', dimensions: 'ga:eventLabel,ga:eventAction,ga:dimension1,ga:dimension2', max_results: 10000, filters: "ga:eventCategory==Search;ga:eventAction==QuerySent", sort: "-ga:totalEvents", start_index: start_index)
 
-    total_found = (response.rows && !response_rows.empty?) ? 0 : (response_rows.length + response.rows.length)
     @logger.info("Paginated find: #{response_rows.length + response.rows.length} of #{response.total_results} queries")
 
     # This is the last iteration, add these rows and return

--- a/lib/report_generators/search_term_by_repo_and_searched_from.rb
+++ b/lib/report_generators/search_term_by_repo_and_searched_from.rb
@@ -1,5 +1,6 @@
 require 'date'
 require File.join(__dir__, '..', 'google_api_client')
+require File.join(File.absolute_path(__dir__), '..', 'json_logger')
 
 class SearchTermByRepoAndSearchedFrom
 
@@ -10,6 +11,7 @@ class SearchTermByRepoAndSearchedFrom
     @end_date      = options[:end_date]
     @output        = options[:output]
     @google_parent_id = options[:google_parent_id]
+    @logger = JsonLogger.new.logger
   end
 
   def report_basename
@@ -31,37 +33,33 @@ class SearchTermByRepoAndSearchedFrom
   def generate_report!
     analytics_client = @google_api_client.analytics_client
 
-    query_response = analytics_client.get_ga_data(@ga_profile_id, @start_date, @end_date, 'ga:totalEvents,ga:uniqueEvents', dimensions: 'ga:eventLabel,ga:eventAction,ga:dimension1,ga:dimension2', max_results: 10000, filters: "ga:eventCategory==Search;ga:eventAction==QuerySent", sort: "-ga:totalEvents")
-    click_response = analytics_client.get_ga_data(@ga_profile_id, @start_date, @end_date, 'ga:totalEvents,ga:uniqueEvents,ga:avgEventValue', dimensions: 'ga:eventLabel,ga:eventAction,ga:dimension1,ga:dimension2', max_results: 10000, filters: "ga:eventCategory==Search;ga:eventAction==Clickthrough", sort: "ga:eventLabel")
+    query_rows = get_query_rows(analytics_client)
+    click_rows = get_click_rows(analytics_client)
 
     queries = []
     clicks  = []
 
-    if query_response.rows
-      query_response.rows.each do |query_row|
-        queries << QueryResponse.new({
-          search_term: query_row[0],
-          action: query_row[1],
-          searched_from: query_row[2],
-          searched_repo: query_row[3],
-          total_events: query_row[4].to_i,
-          unique_events: query_row[5].to_i
-        })
-      end
+    query_rows.each do |query_row|
+      queries << QueryResponse.new({
+        search_term: query_row[0],
+        action: query_row[1],
+        searched_from: query_row[2],
+        searched_repo: query_row[3],
+        total_events: query_row[4].to_i,
+        unique_events: query_row[5].to_i
+      })
     end
 
-    if click_response.rows
-      click_response.rows.each do |click_row|
-        clicks << ClickResponse.new({
-          search_term: click_row[0],
-          action: click_row[1],
-          searched_from: click_row[2],
-          searched_repo: click_row[3],
-          total_events: click_row[4].to_i,
-          unique_events: click_row[5].to_i,
-          mean_ordinality: click_row[6].to_f,
-        })
-      end
+    click_rows.each do |click_row|
+      clicks << ClickResponse.new({
+        search_term: click_row[0],
+        action: click_row[1],
+        searched_from: click_row[2],
+        searched_repo: click_row[3],
+        total_events: click_row[4].to_i,
+        unique_events: click_row[5].to_i,
+        mean_ordinality: click_row[6].to_f,
+      })
     end
 
     CSV.open(report_output_path, 'wb') do |csv|
@@ -247,4 +245,39 @@ class SearchTermByRepoAndSearchedFrom
 
       ordinality_fraction[:ordinality_total] / ordinality_fraction[:click_total]
   end
+
+private
+
+  def get_click_rows(analytics_client, start_index = 1, response_rows = [])
+    response = analytics_client.get_ga_data(@ga_profile_id, @start_date, @end_date, 'ga:totalEvents,ga:uniqueEvents,ga:avgEventValue', dimensions: 'ga:eventLabel,ga:eventAction,ga:dimension1,ga:dimension2', max_results: 10000, filters: "ga:eventCategory==Search;ga:eventAction==Clickthrough", sort: "ga:eventLabel", start_index: start_index)
+
+    @logger.info("Paginated find: #{response_rows.length + response.rows.length} of #{response.total_results} clicks")
+    # This is the last iteration, add these rows and return
+    if !response.next_link
+      response_rows.concat(response.rows)
+    else
+      next_index = CGI.parse(URI.parse(response.next_link).query)["start-index"].first
+      get_click_rows(analytics_client, next_index, response_rows.concat(response.rows))
+    end
+
+    response_rows
+  end
+
+  def get_query_rows(analytics_client, start_index = 1, response_rows = [])
+    response = analytics_client.get_ga_data(@ga_profile_id, @start_date, @end_date, 'ga:totalEvents,ga:uniqueEvents', dimensions: 'ga:eventLabel,ga:eventAction,ga:dimension1,ga:dimension2', max_results: 10000, filters: "ga:eventCategory==Search;ga:eventAction==QuerySent", sort: "-ga:totalEvents", start_index: start_index)
+
+    total_found = (response.rows && !response_rows.empty?) ? 0 : (response_rows.length + response.rows.length)
+    @logger.info("Paginated find: #{response_rows.length + response.rows.length} of #{response.total_results} queries")
+
+    # This is the last iteration, add these rows and return
+    if !response.next_link
+      response_rows.concat(response.rows)
+    else
+      next_index = CGI.parse(URI.parse(response.next_link).query)["start-index"].first
+      get_query_rows(analytics_client, next_index, response_rows.concat(response.rows))
+    end
+
+    response_rows
+  end
+
 end


### PR DESCRIPTION
Allo.

Not much code to it...but this will start paginating our calls to GA.

## The Code

1.  Now we log as we make calls to GA's API, using the `JsonLogger`.
2.  Instead of calling the analytics_client in one fell swoop, we get records by calls to `get_query_rows()` and `get_click_rows`. Those methods are recursive.

## A Very Easy Way To Test Behavior Hasn't Changed

```
# generate a csv in master
(master)$ ruby script/create_analytics_report.rb -s yesterday -e yesterday -a config/google_auth.json -o . -i ga:[OUR-PRODUCTION-GA-ID]

#rename the output
(master)$ mv output_2017-11-21_2017-11-21.csv from_master.csv

(master)$ git checkout ss/add-pagination-SBAR-52

# IMPORTANT: Temporarily change the `max_results` param to 300 and re-run
(ss/add-pagination-SBAR-52)$ ruby script/create_analytics_report.rb -s yesterday -e yesterday -a config/google_auth.json -o . -i ga:[OUR-PRODUCTION-GA-ID]

#rename the output
(ss/add-pagination-SBAR-52)$ mv output_2017-11-21_2017-11-21.csv from_branch.csv

#enjoy the silence...of no diff
(ss/add-pagination-SBAR-52)$ diff from_master.csv from_branch.csv
```